### PR TITLE
Get last location now prefers updates within last 60 seconds.

### DIFF
--- a/lost/src/main/java/com/mapzen/android/lost/Clock.java
+++ b/lost/src/main/java/com/mapzen/android/lost/Clock.java
@@ -1,0 +1,5 @@
+package com.mapzen.android.lost;
+
+public interface Clock {
+    public long getCurrentTimeInMillis();
+}

--- a/lost/src/main/java/com/mapzen/android/lost/SystemClock.java
+++ b/lost/src/main/java/com/mapzen/android/lost/SystemClock.java
@@ -1,0 +1,8 @@
+package com.mapzen.android.lost;
+
+public class SystemClock implements Clock {
+    @Override
+    public long getCurrentTimeInMillis() {
+        return System.currentTimeMillis();
+    }
+}

--- a/lost/src/test/java/com/mapzen/android/lost/TestClock.java
+++ b/lost/src/test/java/com/mapzen/android/lost/TestClock.java
@@ -1,0 +1,14 @@
+package com.mapzen.android.lost;
+
+public class TestClock implements Clock {
+    private long currentTimeInMillis;
+
+    @Override
+    public long getCurrentTimeInMillis() {
+        return currentTimeInMillis;
+    }
+
+    public void setCurrentTimeInMillis(long currentTimeInMillis) {
+        this.currentTimeInMillis = currentTimeInMillis;
+    }
+}


### PR DESCRIPTION
- Returns most accurate update in the last 60 seconds.
- If no updates in the last 60 seconds, returns most recent.

Adapted from http://android-developers.blogspot.com/2011/06/deep-dive-into-location.html
