### PR TITLE
Added GPS_ONLY priority in LocationRequest

### DIFF
--- a/lost/src/main/java/com/mapzen/android/lost/api/LocationRequest.java
+++ b/lost/src/main/java/com/mapzen/android/lost/api/LocationRequest.java
@@ -12,6 +12,7 @@ public final class LocationRequest implements Parcelable {
   public static final int PRIORITY_BALANCED_POWER_ACCURACY = 0x00000066;
   public static final int PRIORITY_LOW_POWER = 0x00000068;
   public static final int PRIORITY_NO_POWER = 0x00000069;
+  public static final int PRIORITY_GPS_ONLY = 0x00000070;
 
   static final long DEFAULT_INTERVAL_IN_MS = 3600000;
   static final long DEFAULT_FASTEST_INTERVAL_IN_MS = 600000;
@@ -97,7 +98,8 @@ public final class LocationRequest implements Parcelable {
     if (priority != PRIORITY_HIGH_ACCURACY
         && priority != PRIORITY_BALANCED_POWER_ACCURACY
         && priority != PRIORITY_LOW_POWER
-        && priority != PRIORITY_NO_POWER) {
+        && priority != PRIORITY_NO_POWER
+        && priority != PRIORITY_GPS_ONLY) {
       throw new IllegalArgumentException("Invalid priority: " + priority);
     }
 

--- a/lost/src/main/java/com/mapzen/android/lost/internal/FusionEngine.java
+++ b/lost/src/main/java/com/mapzen/android/lost/internal/FusionEngine.java
@@ -98,6 +98,11 @@ public class FusionEngine extends LocationEngine implements LocationListener {
             passiveInterval = request.getInterval();
           }
           break;
+        case LocationRequest.PRIORITY_GPS_ONLY:
+          if (request.getInterval() < gpsInterval) {
+            gpsInterval = request.getInterval();
+          }
+          break;
         default:
           break;
       }

--- a/lost/src/main/java/com/mapzen/android/lost/internal/LocationSettingsResultRequest.java
+++ b/lost/src/main/java/com/mapzen/android/lost/internal/LocationSettingsResultRequest.java
@@ -96,6 +96,9 @@ class LocationSettingsResultRequest extends PendingResult<LocationSettingsResult
         case LocationRequest.PRIORITY_LOW_POWER:
           needNetwork = true;
           break;
+        case LocationRequest.PRIORITY_GPS_ONLY:
+          needGps = true;
+          break;
         default:
           break;
       }


### PR DESCRIPTION
### Overview

### Added a new LocationRequest priority for GPS only devices

Stock AOSP ROM's do not come with a Network Location Provider, and the library throws the exception `Unable to register for network updates. java.lang.IllegalArgumentException: provider doesn't exist: network`, which is handled, but pollutes the logs. This PR adds a new LocationRequest priority `PRIORITY_GPS_ONLY`, which just listens to GPS sensor data.
