### PR TITLE
fix (#265): set elapsed realtime when mocking a trace for SDK>JELLY_BEAN_MR1

### DIFF
--- a/lost/src/main/java/com/mapzen/android/lost/internal/TraceThread.java
+++ b/lost/src/main/java/com/mapzen/android/lost/internal/TraceThread.java
@@ -7,6 +7,7 @@ import org.xml.sax.SAXException;
 
 import android.content.Context;
 import android.location.Location;
+import android.os.Build;
 import android.os.Handler;
 
 import java.io.File;
@@ -96,6 +97,9 @@ class TraceThread extends Thread {
     location.setLatitude(Double.parseDouble(lat));
     location.setLongitude(Double.parseDouble(lng));
     location.setTime(System.currentTimeMillis());
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1) {
+      location.setElapsedRealtimeNanos(android.os.SystemClock.elapsedRealtimeNanos());
+    }
     if (speedList.item(i) != null && speedList.item(i).getFirstChild() != null) {
       location.setSpeed(Float.parseFloat(speedList.item(i).getFirstChild().getNodeValue()));
     }


### PR DESCRIPTION
### Overview
On devices with SDK >= JELLY_BEAN_MR1, tracing a GPX file won't work anymore, because the changes from #244 introduced the usage of the real time clock in nanoseconds, but forgot to have mocked locations also set the corresponding field.
I reported this as issue #265 

### Proposed Changes
Added code that sets elapsed realtime nanos if SDK >= JELLY_BEAN_MR1