### PR TITLE
Update AndroidManifest.xml for Android 12 (SDK 31)

### DIFF
--- a/lost/src/main/AndroidManifest.xml
+++ b/lost/src/main/AndroidManifest.xml
@@ -19,7 +19,9 @@
     <service
         android:name="com.mapzen.android.lost.internal.FusedLocationProviderService"
         android:process=":lost"/>
-    <service android:name="com.mapzen.android.lost.internal.GeofencingIntentService">
+    <service 
+        android:name="com.mapzen.android.lost.internal.GeofencingIntentService"
+        android:exported="true">
       <intent-filter>
         <action android:name="com.mapzen.lost.action.ACTION_GEOFENCING_SERVICE"/>
       </intent-filter>


### PR DESCRIPTION
### Overview

Android 12 (SDK 31) requires that when you are using intent-filters the `android:exported` attribute should be provided explicitly. Reference: https://developer.android.com/guide/topics/manifest/activity-element#exported

### Proposed Changes

Add the `android:exported:"true"` attribute to the services that use intent-filters. 