### PR TITLE
Update android 12

### DIFF
--- a/lost/src/main/AndroidManifest.xml
+++ b/lost/src/main/AndroidManifest.xml
@@ -19,7 +19,9 @@
     <service
         android:name="com.mapzen.android.lost.internal.FusedLocationProviderService"
         android:process=":lost"/>
-    <service android:name="com.mapzen.android.lost.internal.GeofencingIntentService">
+    <service 
+        android:name="com.mapzen.android.lost.internal.GeofencingIntentService"
+        android:exported="true">
       <intent-filter>
         <action android:name="com.mapzen.lost.action.ACTION_GEOFENCING_SERVICE"/>
       </intent-filter>

--- a/lost/src/main/AndroidManifest.xml
+++ b/lost/src/main/AndroidManifest.xml
@@ -21,7 +21,7 @@
         android:process=":lost"/>
     <service 
         android:name="com.mapzen.android.lost.internal.GeofencingIntentService"
-        android:exported="true">
+        android:exported="false">
       <intent-filter>
         <action android:name="com.mapzen.lost.action.ACTION_GEOFENCING_SERVICE"/>
       </intent-filter>


### PR DESCRIPTION
### Overview

Android 12 (SDK 31) requires that when you are using intent-filters the `android:exported` attribute should be provided explicitly. Reference: https://developer.android.com/guide/topics/manifest/activity-element#exported

### Proposed Changes

Add the `android:exported="false"` attribute to the service(s) that use intent-filters.
